### PR TITLE
(Server) User and device connectionHubs are registered as singleInsta…

### DIFF
--- a/IglooSmartHome/Server/IglooSmartHomeService/AppStart/Startup.cs
+++ b/IglooSmartHome/Server/IglooSmartHomeService/AppStart/Startup.cs
@@ -3,11 +3,9 @@ using Autofac.Integration.SignalR;
 using Autofac.Integration.WebApi;
 using Azure.Server.Utils.Email;
 using IglooSmartHome.AppStart;
-using IglooSmartHome.Controllers;
 using IglooSmartHome.DataObjects;
 using IglooSmartHome.Models;
 using IglooSmartHome.Services;
-using IglooSmartHomeService.Controllers;
 using IglooSmartHomeService.Services;
 using IglooSmartHomeService.SignalR;
 using Microsoft.AspNet.SignalR;
@@ -62,7 +60,6 @@ namespace IglooSmartHome.AppStart
         {
             var builder = new ContainerBuilder();
             builder.RegisterApiControllers(Assembly.GetExecutingAssembly());
-            builder.RegisterHubs(Assembly.GetExecutingAssembly());
 
             builder.RegisterType<SendgridService>()
                 .As<IEmailService<Account>>();
@@ -71,6 +68,13 @@ namespace IglooSmartHome.AppStart
             builder.RegisterType<UserConnectionsMappingService>()
                 .SingleInstance();
             builder.RegisterType<IglooSmartHomeContext>();
+
+            builder.RegisterType<UserConnectionHub>()
+                .ExternallyOwned()
+                .SingleInstance();
+            builder.RegisterType<DeviceConnectionHub>()
+                .ExternallyOwned()
+                .SingleInstance();
 
             return builder.Build();
         }

--- a/IglooSmartHome/Server/IglooSmartHomeService/SignalR/DeviceConnectionHub.cs
+++ b/IglooSmartHome/Server/IglooSmartHomeService/SignalR/DeviceConnectionHub.cs
@@ -1,13 +1,9 @@
-﻿using Autofac;
-using Azure.Server.Utils.Extensions;
+﻿using Azure.Server.Utils.Extensions;
 using IglooSmartHome.Models;
 using IglooSmartHomeService.Services;
 using Microsoft.AspNet.SignalR;
-using System;
-using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
-using System.Security.Claims;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace IglooSmartHomeService.SignalR
@@ -29,6 +25,8 @@ namespace IglooSmartHomeService.SignalR
         public override Task OnConnected()
         {
             var deviceId = Context.User.GetCurrentUserAccount(_context.Devices).Id;
+            Trace.TraceInformation(
+                $"Device with id '{deviceId}' was connected with connection id '{Context.ConnectionId}'");
             _connections.Add(deviceId, Context.ConnectionId);
             return base.OnConnected();
         }
@@ -36,6 +34,8 @@ namespace IglooSmartHomeService.SignalR
         public override Task OnDisconnected(bool stopCalled)
         {
             var deviceId = Context.User.GetCurrentUserAccount(_context.Devices).Id;
+            Trace.TraceInformation(
+                $"Device with id '{deviceId}' was disconnected with connection id '{Context.ConnectionId}'");
             _connections.Remove(deviceId, Context.ConnectionId);
             return base.OnDisconnected(stopCalled);
         }


### PR DESCRIPTION
Enabled server tracing for signalR connection. Connection hubs are registered as singleInstance to prevent message duplications.